### PR TITLE
Added Entity Access Gateway which manages Task entity creation

### DIFF
--- a/src/main/java/entity_accessors/NewTaskData.java
+++ b/src/main/java/entity_accessors/NewTaskData.java
@@ -1,0 +1,19 @@
+package main.java.entity_accessors;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class NewTaskData {
+    public final String taskName;
+    public final Duration timeNeeded;
+    public final LocalDateTime deadline;
+    public final List<String> subTasks;
+
+    public NewTaskData(String taskName, Duration timeNeeded, LocalDateTime deadline, List<String> subTasks) {
+        this.taskName = taskName;
+        this.timeNeeded = timeNeeded;
+        this.deadline = deadline;
+        this.subTasks = subTasks;
+    }
+}

--- a/src/main/java/entity_accessors/TaskEntityManager.java
+++ b/src/main/java/entity_accessors/TaskEntityManager.java
@@ -1,0 +1,26 @@
+package main.java.entity_accessors;
+
+import main.java.entities.Task;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TaskEntityManager implements TaskManager {
+
+    private final Map<Integer, Task> taskMap;
+
+    public TaskEntityManager() {
+        taskMap = new HashMap<>();
+    }
+
+    public boolean addTask(NewTaskData taskData) {
+        Task task = new Task(taskData.taskName, taskData.timeNeeded, taskData.deadline, taskData.subTasks);
+        int taskId = task.getId();
+        if (taskMap.containsKey(taskId)) {
+            return false;
+        } else {
+            taskMap.put(taskId, task);
+            return true;
+        }
+    }
+}

--- a/src/main/java/entity_accessors/TaskManager.java
+++ b/src/main/java/entity_accessors/TaskManager.java
@@ -1,0 +1,7 @@
+package main.java.entity_accessors;
+
+public interface TaskManager {
+
+    boolean addTask(NewTaskData task);
+
+}

--- a/src/tests/entity_accessors/TestEntityManagerTest.java
+++ b/src/tests/entity_accessors/TestEntityManagerTest.java
@@ -1,0 +1,30 @@
+package tests.entity_accessors;
+
+import main.java.entity_accessors.NewTaskData;
+import main.java.entity_accessors.TaskEntityManager;
+import main.java.entity_accessors.TaskManager;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestEntityManagerTest {
+
+    @Test
+    void addNewTask() {
+
+        String taskName = "Test task";
+        Duration timeNeeded = Duration.ofMinutes(10);
+        LocalDateTime deadline = LocalDateTime.of(2021, 10, 23, 7, 10);
+        List<String> subTasks = new ArrayList<>();
+
+        NewTaskData newTaskData = new NewTaskData(taskName, timeNeeded, deadline, subTasks);
+
+        TaskManager tm = new TaskEntityManager();
+        tm.addTask(newTaskData);
+
+    }
+
+}


### PR DESCRIPTION
To be merged into #30 

Rationale for adding `NewTaskData` instead of an actual `Task`:
Looking ahead to having an external file storing tasks, it might be the case that we never actually need a Task class object. We just pass in the info that would create the notion of the entity but actually be writing it into the file.
