### PR TITLE
Invert EventController's dependency on EventGetter to the CalendarEventDisplayBoundary interface

### DIFF
--- a/src/main/java/ApplicationDriver.java
+++ b/src/main/java/ApplicationDriver.java
@@ -63,18 +63,7 @@ public class ApplicationDriver {
             case "0":
                 return false;
             case "1":
-                List<HashMap<String, String>> allEventsData = controller.getEvents();
-                if (allEventsData.size() == 0) {
-                    System.out.println("No events have been created");
-                }
-                for (HashMap<String, String> eventData : allEventsData) {
-                    String output = "Event: " + eventData.get("name") + ", "
-                                        + "start time = " + eventData.get("start") + ", "
-                                        + "end time = " + eventData.get("end") + ", "
-                                        + "tags = " + eventData.get("tags") + ", "
-                                        + "dates = " + eventData.get("dates");
-                    System.out.println(output);
-                }
+                controller.presentEvents();
                 break;
             case "2":
                 printTasks();

--- a/src/main/java/interface_adapters/EventController.java
+++ b/src/main/java/interface_adapters/EventController.java
@@ -3,6 +3,7 @@ package main.java.interface_adapters;
 
 import main.java.use_case.CalendarEventCreationBoundary;
 import main.java.use_case.CalendarEventData;
+import main.java.use_case.CalendarEventDisplayBoundary;
 import main.java.use_case.EventAdder;
 import main.java.use_case.EventScheduler;
 import main.java.use_case.EventGetter;
@@ -20,20 +21,12 @@ public class EventController {
 
     protected final CalendarEventCreationBoundary eventAdder;
     protected final EventScheduler eventScheduler;
-    protected final EventGetter eventGetter;
+    protected final CalendarEventDisplayBoundary eventGetter;
 
-    public EventController(CalendarEventCreationBoundary eventAdder, EventScheduler eventScheduler, EventGetter eventGetter) {
+    public EventController(CalendarEventCreationBoundary eventAdder, EventScheduler eventScheduler, CalendarEventDisplayBoundary eventGetter) {
         this.eventAdder = eventAdder;
         this.eventScheduler = eventScheduler;
         this.eventGetter = eventGetter;
-    }
-
-    /**
-     * Returns a list containing mappings of event attributes
-     * and their corresponding values
-     */
-    public List<HashMap<String, String>> getEvents() {
-        return eventGetter.getEvents();
     }
 
     /**
@@ -70,6 +63,10 @@ public class EventController {
                                         tags, dates));
         }
         return false;
+    }
+
+    public void presentEvents() {
+        eventGetter.presentCalendar();
     }
 
 }

--- a/src/main/java/interface_adapters/MainController.java
+++ b/src/main/java/interface_adapters/MainController.java
@@ -5,6 +5,7 @@ import main.java.entity_gateway.EventEntityManager;
 import main.java.entity_gateway.TodoEntityManager;
 import main.java.entity_gateway.TodoListManager;
 import main.java.use_case.CalendarEventCreationBoundary;
+import main.java.use_case.CalendarEventDisplayBoundary;
 import main.java.use_case.CalendarEventPresenter;
 import main.java.use_case.EventAdder;
 import main.java.use_case.EventFromTaskCreator;
@@ -38,7 +39,7 @@ public class MainController {
         EventScheduler eventScheduler = new EventScheduler(calendarManager);
 
         CalendarEventPresenter eventPresenter = new ConsoleEventPresenter();
-        EventGetter eventGetter = new EventGetter(calendarManager, eventPresenter);
+        CalendarEventDisplayBoundary eventGetter = new EventGetter(calendarManager, eventPresenter);
 
         eventController = new EventController(eventAdder, eventScheduler, eventGetter);
 
@@ -50,14 +51,6 @@ public class MainController {
 
         EventFromTaskCreatorBoundary eventFromTaskCreator = new EventFromTaskCreator(todoListManager, calendarManager);
         taskToEventController = new TaskToEventController(eventController, eventFromTaskCreator);
-    }
-
-    /**
-     * Return a list of events data in the format of a map, with keys as
-     * "name", "start", and "end"
-     */
-    public List<HashMap<String, String>> getEvents() {
-        return eventController.getEvents();
     }
 
     /**
@@ -90,6 +83,12 @@ public class MainController {
                                HashSet<String> tags, LocalDate date) {
         return eventController.createEvent(eventName, startTime, endTime, tags, date);
     }
+
+
+    public void presentEvents() {
+        eventController.presentEvents();
+    }
+
     /**
      * creates a task and adds it to the todolist
      */

--- a/src/main/java/use_case/EventGetter.java
+++ b/src/main/java/use_case/EventGetter.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-public class EventGetter implements GetEvent, CalendarEventDisplayBoundary {
+public class EventGetter implements CalendarEventDisplayBoundary {
     Calendar calendar;
 
     private final CalendarManager calendarManager;
@@ -18,21 +18,6 @@ public class EventGetter implements GetEvent, CalendarEventDisplayBoundary {
     public EventGetter(CalendarManager calendarManager, CalendarEventPresenter eventPresenter) {
         this.calendarManager = calendarManager;
         this.eventPresenter = eventPresenter;
-    }
-
-    /**
-     * Returns a list containing mappings of event attributes
-     * and their corresponding values, with keys as "name", "start",
-     * "end", "tags", and "dates
-     */
-    @Override
-    public List<HashMap<String, String>> getEvents() {
-        List<HashMap<String, String>> event_data = new ArrayList<>();
-        for(Event event : calendar.getEvents()) {
-            event_data.add(getEvent(event));
-        }
-
-        return event_data;
     }
 
     private HashMap<String, String> getEvent(Event event) {

--- a/src/main/java/use_case/GetEvent.java
+++ b/src/main/java/use_case/GetEvent.java
@@ -1,8 +1,0 @@
-package main.java.use_case;
-
-import java.util.HashMap;
-import java.util.List;
-
-public interface GetEvent {
-    List<HashMap<String, String>> getEvents();
-}


### PR DESCRIPTION
Applying DIP to the dependency of the higher level module `EventController` on the lower level module `EventGetter`. This inversion also got rid of returning methods, which were replaced with just presentation calls.