### PR TITLE
change the return type to long

### DIFF
--- a/src/main/java/services/event_creation/CalendarEventCreationBoundary.java
+++ b/src/main/java/services/event_creation/CalendarEventCreationBoundary.java
@@ -2,7 +2,7 @@ package services.event_creation;
 
 public interface CalendarEventCreationBoundary {
 
-    void addEvent(CalendarEventModel eventData);
+    long addEvent(CalendarEventModel eventData);
 
     void markEventAsCompleted(long eventId);
 }

--- a/src/main/java/services/event_creation/EventAdder.java
+++ b/src/main/java/services/event_creation/EventAdder.java
@@ -11,8 +11,8 @@ public class EventAdder implements CalendarEventCreationBoundary {
     }
 
     @Override
-    public void addEvent(CalendarEventModel eventData) {
-        calendarManager.addEvent(eventData);
+    public long addEvent(CalendarEventModel eventData) {
+        return calendarManager.addEvent(eventData);
     }
 
     @Override

--- a/src/main/java/services/task_creation/TaskAdder.java
+++ b/src/main/java/services/task_creation/TaskAdder.java
@@ -11,8 +11,8 @@ public class TaskAdder implements TodoListTaskCreationBoundary {
     }
 
     @Override
-    public void addTask(TodoListTaskCreationModel taskData) {
-        todoListManager.addTask(taskData);
+    public long addTask(TodoListTaskCreationModel taskData) {
+        return todoListManager.addTask(taskData);
     }
 
     @Override

--- a/src/main/java/services/task_creation/TodoListTaskCreationBoundary.java
+++ b/src/main/java/services/task_creation/TodoListTaskCreationBoundary.java
@@ -2,7 +2,7 @@ package services.task_creation;
 
 public interface TodoListTaskCreationBoundary {
 
-    void addTask(TodoListTaskCreationModel taskData);
+    long addTask(TodoListTaskCreationModel taskData);
 
     void completeTask(long taskId);
 


### PR DESCRIPTION
The return type of some adding methods are still `void` after PR #97. I updated them in this PR.