### PR TITLE
Removed Concrete Dependency on TaskGetter 

### DIFF
--- a/src/main/java/console_app/MainController.java
+++ b/src/main/java/console_app/MainController.java
@@ -22,7 +22,10 @@ import services.task_creation.TodoListTaskCreationBoundary;
 import services.task_creation.TaskSaver;
 import services.task_presentation.TaskGetter;
 import services.task_presentation.TaskInfo;
+import services.task_presentation.TaskOutputter;
+import services.task_presentation.TodoListDisplayBoundary;
 import services.task_presentation.TodoListPresenter;
+import services.task_presentation.TodoListRequestBoundary;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -63,10 +66,11 @@ public class MainController {
         eventController = new EventController(eventAdder, eventScheduler, eventGetter,  eventSaver);
 
         TodoListPresenter taskPresenter = new ConsoleTaskPresenter(applicationDriver);
-        TaskGetter taskGetter = new TaskGetter(todoListManager, taskPresenter);
+        TodoListRequestBoundary taskGetter = new TaskGetter(todoListManager);
+        TodoListDisplayBoundary taskOutputter = new TaskOutputter(todoListManager, taskPresenter);
         TodoListTaskCreationBoundary taskAdder = new TaskAdder(todoListManager);
         TaskSaver taskSaver = new TaskSaver(todoListManager);
-        taskController = new TaskController(taskGetter, taskAdder, taskSaver);
+        taskController = new TaskController(taskGetter, taskOutputter, taskAdder, taskSaver);
 
         taskToEventController = new TaskToEventController(eventController, eventScheduler);
         pomodoroController = new PomodoroController();

--- a/src/main/java/console_app/task_adapters/TaskController.java
+++ b/src/main/java/console_app/task_adapters/TaskController.java
@@ -2,8 +2,9 @@ package console_app.task_adapters;
 
 import services.task_creation.TaskSaver;
 import services.task_creation.TodoListTaskCreationBoundary;
-import services.task_presentation.TaskGetter;
 import services.task_presentation.TaskInfo;
+import services.task_presentation.TodoListDisplayBoundary;
+import services.task_presentation.TodoListRequestBoundary;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -12,12 +13,15 @@ import java.util.List;
 import java.util.Map;
 
 public class TaskController {
-    private final TaskGetter taskGetter;
+    private final TodoListRequestBoundary taskGetter;
+    private final TodoListDisplayBoundary taskOutputter;
     private final TodoListTaskCreationBoundary taskAdder;
     private final TaskSaver taskSaver;
 
-    public TaskController(TaskGetter taskGetter, TodoListTaskCreationBoundary taskAdder, TaskSaver taskSaver) {
+    public TaskController(TodoListRequestBoundary taskGetter, TodoListDisplayBoundary taskOutputter,
+                          TodoListTaskCreationBoundary taskAdder, TaskSaver taskSaver) {
         this.taskGetter = taskGetter;
+        this.taskOutputter = taskOutputter;
         this.taskAdder = taskAdder;
         this.taskSaver = taskSaver;
     }
@@ -26,7 +30,7 @@ public class TaskController {
      * Displays all tasks.
      */
     public void presentAllTasks() {
-        taskGetter.presentAllTasks();
+        taskOutputter.presentAllTasks();
     }
 
     public void createTask(String taskName, Duration timeNeeded,
@@ -53,7 +57,7 @@ public class TaskController {
      * @return a mapping of task's position in the presented list and id
      */
     public Map<Integer, Long> presentAllTasksForUserSelection() {
-        return taskGetter.presentAllTasksForUserSelection();
+        return taskOutputter.presentAllTasksForUserSelection();
     }
 
     public void saveTodoList(String filename) throws IOException {

--- a/src/main/java/services/task_presentation/TaskGetter.java
+++ b/src/main/java/services/task_presentation/TaskGetter.java
@@ -6,14 +6,12 @@ import data_gateway.TodoListManager;
 import java.util.List;
 import java.util.Map;
 
-public class TaskGetter implements TodoListDisplayBoundary {
+public class TaskGetter implements TodoListRequestBoundary {
 
     private final TodoListManager todoListManager;
-    private final TodoListPresenter taskPresenter;
 
-    public TaskGetter(TodoListManager todoListManager, TodoListPresenter taskPresenter) {
+    public TaskGetter(TodoListManager todoListManager) {
         this.todoListManager = todoListManager;
-        this.taskPresenter = taskPresenter;
     }
 
     /**
@@ -21,6 +19,7 @@ public class TaskGetter implements TodoListDisplayBoundary {
      * @param id id of a task
      * @return the corresponding task as a TaskInfo
      */
+    @Override
     public TaskInfo getTaskById(Long id) {
         Map<Long, List<TaskReader>> taskMap = todoListManager.getAllTasks();
         for (List<TaskReader> todoListTasks : taskMap.values())
@@ -32,24 +31,4 @@ public class TaskGetter implements TodoListDisplayBoundary {
         return null;
     }
 
-    /**
-     * Get tasks from the database through data gateway and
-     * pass the tasks as DTOs to the presenter to present all tasks.
-     */
-    public void presentAllTasks() {
-        Map<Long, List<TaskReader>> taskReaders = todoListManager.getAllTasks();
-        TodoListsInfo todoListInfo = new TodoListInfoFromTaskReaders(taskReaders);
-        taskPresenter.presentTasks(todoListInfo);
-    }
-
-    /**
-     * Get tasks from the database through data gateway and
-     * pass the tasks as DTOs to the presenter to present all tasks in an ordered list.
-     * @return a mapping of task's position in the presented list and id
-     */
-    public Map<Integer, Long> presentAllTasksForUserSelection() {
-        Map<Long, List<TaskReader>> taskReaders = todoListManager.getAllTasks();
-        TodoListsInfo todoListInfo = new TodoListInfoFromTaskReaders(taskReaders);
-        return taskPresenter.presentTasksForUserSelection(todoListInfo);
-    }
 }

--- a/src/main/java/services/task_presentation/TaskOutputter.java
+++ b/src/main/java/services/task_presentation/TaskOutputter.java
@@ -1,0 +1,41 @@
+package services.task_presentation;
+
+import data_gateway.TaskReader;
+import data_gateway.TodoListManager;
+
+import java.util.List;
+import java.util.Map;
+
+public class TaskOutputter implements TodoListDisplayBoundary {
+    private final TodoListManager todoListManager;
+    private final TodoListPresenter taskPresenter;
+
+    public TaskOutputter(TodoListManager todoListManager, TodoListPresenter taskPresenter) {
+        this.todoListManager = todoListManager;
+        this.taskPresenter = taskPresenter;
+    }
+    /**
+     * Get tasks from the database through data gateway and
+     * pass the tasks as DTOs to the presenter to present all tasks.
+     */
+    @Override
+    public void presentAllTasks() {
+        Map<Long, List<TaskReader>> taskReaders = todoListManager.getAllTasks();
+        TodoListsInfo todoListInfo = new TodoListInfoFromTaskReaders(taskReaders);
+        taskPresenter.presentTasks(todoListInfo);
+    }
+
+
+    /**
+     * Get tasks from the database through data gateway and
+     * pass the tasks as DTOs to the presenter to present all tasks in an ordered list.
+     * @return a mapping of task's position in the presented list and id
+     */
+    @Override
+    public Map<Integer, Long> presentAllTasksForUserSelection() {
+        Map<Long, List<TaskReader>> taskReaders = todoListManager.getAllTasks();
+        TodoListsInfo todoListInfo = new TodoListInfoFromTaskReaders(taskReaders);
+        return taskPresenter.presentTasksForUserSelection(todoListInfo);
+    }
+
+}

--- a/src/main/java/services/task_presentation/TodoListDisplayBoundary.java
+++ b/src/main/java/services/task_presentation/TodoListDisplayBoundary.java
@@ -1,5 +1,9 @@
 package services.task_presentation;
 
+import java.util.Map;
+
 public interface TodoListDisplayBoundary {
+    void presentAllTasks();
+    Map<Integer, Long> presentAllTasksForUserSelection();
 
 }

--- a/src/main/java/services/task_presentation/TodoListRequestBoundary.java
+++ b/src/main/java/services/task_presentation/TodoListRequestBoundary.java
@@ -1,0 +1,5 @@
+package services.task_presentation;
+
+public interface TodoListRequestBoundary {
+    TaskInfo getTaskById(Long id);
+}


### PR DESCRIPTION
Segregating `TaskGetter` into two classes, `TaskGetter` which implements `get-()` style methods and `TaskOutputter` which implements `present-()` style methods

related to #62