### PR TITLE
updated types of EventScheduler variables

### DIFF
--- a/src/main/java/console_app/MainController.java
+++ b/src/main/java/console_app/MainController.java
@@ -13,6 +13,7 @@ import services.Snowflake;
 import services.event_creation.CalendarEventCreationBoundary;
 import services.event_creation.EventAdder;
 import services.event_creation.EventSaver;
+import services.event_from_task_creation.CalendarAnalyzer;
 import services.event_from_task_creation.EventScheduler;
 import services.event_presentation.CalendarEventPresenter;
 import services.event_presentation.EventGetter;
@@ -45,7 +46,7 @@ public class MainController {
 
         CalendarManager calendarManager = new EventEntityManager(snowflake);
         CalendarEventCreationBoundary eventAdder = new EventAdder(calendarManager);
-        EventScheduler eventScheduler = new EventScheduler(calendarManager);
+        CalendarAnalyzer eventScheduler = new EventScheduler(calendarManager);
         TodoListManager todoListManager = new TodoEntityManager(snowflake);
 
         try {

--- a/src/main/java/console_app/task_to_event_adapters/TaskToEventController.java
+++ b/src/main/java/console_app/task_to_event_adapters/TaskToEventController.java
@@ -2,7 +2,6 @@ package console_app.task_to_event_adapters;
 
 import console_app.event_adapters.EventController;
 import services.event_from_task_creation.CalendarAnalyzer;
-import services.event_from_task_creation.EventScheduler;
 import services.task_presentation.TaskInfo;
 
 import java.time.Duration;
@@ -14,7 +13,7 @@ public class TaskToEventController {
 
     protected final EventController eventController;
 
-    public TaskToEventController(EventController eventController, EventScheduler eventScheduler) {
+    public TaskToEventController(EventController eventController, CalendarAnalyzer eventScheduler) {
         this.eventController = eventController;
         this.eventScheduler = eventScheduler;
     }


### PR DESCRIPTION
Some concrete variable types prevented building the `CalendarAnalyzer` with a factory. Variables ideally should be abstractions not concretions, so the variables with the `EventScheduler` type were updated to be `CalendarAnalyzer`