### PR TITLE
Created view model factory 

### DIFF
--- a/src/main/java/gui/GUIDriver.java
+++ b/src/main/java/gui/GUIDriver.java
@@ -1,5 +1,7 @@
 package gui;
 
+import gui.utility.AdaptedFXMLLoader;
+import gui.view.MonthlyCalendarController;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
@@ -12,7 +14,10 @@ public class GUIDriver extends Application {
 
     @Override
     public void start(Stage primaryStage) throws Exception{
-        Parent root = FXMLLoader.load(Objects.requireNonNull(getClass().getResource("/basicPage.fxml")));
+        AdaptedFXMLLoader loader = new AdaptedFXMLLoader();
+        loader.setLocation(Objects.requireNonNull(getClass().getResource("/monthlyCalendar.fxml")));
+        Parent root = loader.load();
+
         primaryStage.setTitle("Project Time");
         primaryStage.setScene(new Scene(root, 1000, 800));
         primaryStage.show();

--- a/src/main/java/gui/model/EventModelManager.java
+++ b/src/main/java/gui/model/EventModelManager.java
@@ -1,0 +1,20 @@
+package gui.model;
+
+import data_gateway.event.CalendarManager;
+import data_gateway.event.EventReader;
+
+import java.util.List;
+
+public class EventModelManager {
+    private final List<EventReader> eventReaderList;
+    private final CalendarManager calendarManager;
+
+    public EventModelManager(CalendarManager calendarManager) {
+        this.calendarManager = calendarManager;
+        this.eventReaderList = calendarManager.getAllEvents();
+    }
+
+    public List<EventReader> getEvents() {
+        return this.eventReaderList;
+    }
+}

--- a/src/main/java/gui/utility/AdaptedFXMLLoader.java
+++ b/src/main/java/gui/utility/AdaptedFXMLLoader.java
@@ -1,0 +1,55 @@
+package gui.utility;
+
+import data_gateway.event.CalendarManager;
+import data_gateway.event.EventEntityManager;
+import gui.model.EventModelManager;
+import gui.view.BasicPageController;
+import gui.view.MonthlyCalendarController;
+import gui.view.ViewModelBindingController;
+import gui.view.WeeklyCalendarController;
+import gui.view_model.ViewModel;
+import gui.view_model.ViewModelFactory;
+import javafx.fxml.FXMLLoader;
+import services.Snowflake;
+
+import java.io.IOException;
+
+public class AdaptedFXMLLoader extends FXMLLoader {
+    private final ViewModelFactory viewModelFactory;
+
+    public AdaptedFXMLLoader() {
+        super();
+
+        // TODO: model manager will be changed to observable repos
+        Snowflake snowflake = new Snowflake(0, 0, 0);
+        CalendarManager calendarManager = new EventEntityManager(snowflake);
+        try {
+            calendarManager.loadEvents("EventData.json");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        EventModelManager manager = new EventModelManager(calendarManager);
+        this.viewModelFactory = new ViewModelFactory(manager);
+    }
+
+    @Override
+    public <Parent> Parent load() throws IOException {
+        Parent root = super.load();
+        ViewModel viewModel = null;
+        ViewModelBindingController controller = this.getController();
+        if (controller instanceof MonthlyCalendarController) {
+            viewModel = viewModelFactory.getMonthlyCalendarViewModel();
+        } else if (controller instanceof WeeklyCalendarController) {
+            viewModel = viewModelFactory.getWeeklyCalendarViewModel();
+        }
+
+        if (viewModel != null) {
+            controller.init(viewModel);
+        } else {
+            System.err.println("Error in injecting view model to a javafx controller");
+        }
+
+        return root;
+    }
+}

--- a/src/main/java/gui/utility/NavigationHelper.java
+++ b/src/main/java/gui/utility/NavigationHelper.java
@@ -20,6 +20,8 @@ import java.util.Objects;
  */
 public final class NavigationHelper {
 
+    private static final AdaptedFXMLLoader loader = new AdaptedFXMLLoader();
+
     private NavigationHelper() {
     }
 
@@ -51,7 +53,8 @@ public final class NavigationHelper {
      * @throws IOException if the resource file cannot be found
      */
     public static void enterMonthlyCalendarPage(Event event) throws IOException {
-        Parent root = FXMLLoader.load(Objects.requireNonNull(NavigationHelper.class.getResource("/monthlyCalendar.fxml")));
+        loader.setLocation(Objects.requireNonNull(NavigationHelper.class.getResource("/monthlyCalendar.fxml")));
+        Parent root = loader.load();
         setNewScene(event, root);
     }
 
@@ -61,7 +64,8 @@ public final class NavigationHelper {
      * @throws IOException if the resource file cannot be found
      */
     private static void enterWeeklyCalendarPage(ActionEvent event) throws IOException {
-        Parent root = FXMLLoader.load(Objects.requireNonNull(NavigationHelper.class.getResource("/weeklyCalendar.fxml")));
+        loader.setLocation(Objects.requireNonNull(NavigationHelper.class.getResource("/weeklyCalendar.fxml")));
+        Parent root = loader.load();
         setNewScene(event, root);
     }
 
@@ -71,7 +75,8 @@ public final class NavigationHelper {
      * @throws IOException if the resource file cannot be found
      */
     private static void enterDailyCalendarPage(ActionEvent event) throws IOException {
-        Parent root = FXMLLoader.load(Objects.requireNonNull(NavigationHelper.class.getResource("/dailyCalendar.fxml")));
+        loader.setLocation(Objects.requireNonNull(NavigationHelper.class.getResource("/dailyCalendar.fxml")));
+        Parent root = loader.load();
         setNewScene(event, root);
     }
 
@@ -98,7 +103,8 @@ public final class NavigationHelper {
      * @throws IOException if the resource file cannot be found
      */
     public static void enterHomePage(MouseEvent event) throws IOException {
-        Parent root = FXMLLoader.load(Objects.requireNonNull(NavigationHelper.class.getResource("/basicPage.fxml")));
+        loader.setLocation(Objects.requireNonNull(NavigationHelper.class.getResource("/basicPage.fxml")));
+        Parent root = loader.load();
         setNewScene(event, root);
     }
 

--- a/src/main/java/gui/view/BasicPageController.java
+++ b/src/main/java/gui/view/BasicPageController.java
@@ -2,13 +2,14 @@ package gui.view;
 
 import com.jfoenix.controls.JFXDrawer;
 import gui.utility.NavigationHelper;
+import gui.view_model.ViewModel;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.layout.AnchorPane;
 import java.net.URL;
 import java.util.ResourceBundle;
 
-public class BasicPageController implements Initializable {
+public class BasicPageController implements Initializable, ViewModelBindingController {
 
     @FXML
     private JFXDrawer collapsedNavPanel;
@@ -22,5 +23,10 @@ public class BasicPageController implements Initializable {
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         NavigationHelper.initializeNavPanel(extendedNavPanel, collapsedNavPanel);
+    }
+
+    @Override
+    public void init(ViewModel viewModel) {
+
     }
 }

--- a/src/main/java/gui/view/DailyCalendarController.java
+++ b/src/main/java/gui/view/DailyCalendarController.java
@@ -2,6 +2,7 @@ package gui.view;
 
 import com.jfoenix.controls.JFXDrawer;
 import gui.utility.NavigationHelper;
+import gui.view_model.ViewModel;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -12,7 +13,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
 
-public class DailyCalendarController implements Initializable {
+public class DailyCalendarController implements Initializable, ViewModelBindingController {
 
     @FXML
     private JFXDrawer collapsedNavPanel;
@@ -37,5 +38,10 @@ public class DailyCalendarController implements Initializable {
     void calendarTypeSelected(ActionEvent event) throws IOException {
         String selected = calendarType.getValue();
         NavigationHelper.switchCalendarPageType(event, selected);
+    }
+
+    @Override
+    public void init(ViewModel viewModel) {
+
     }
 }

--- a/src/main/java/gui/view/MonthlyCalendarController.java
+++ b/src/main/java/gui/view/MonthlyCalendarController.java
@@ -1,8 +1,19 @@
 package gui.view;
 
+import com.calendarfx.model.Calendar;
+import com.calendarfx.model.CalendarEvent;
+import com.calendarfx.model.CalendarSource;
+import com.calendarfx.model.Entry;
+import com.calendarfx.view.page.MonthPage;
 import com.jfoenix.controls.JFXDrawer;
 import gui.utility.NavigationHelper;
+import gui.view_model.MonthlyCalendarViewModel;
+import gui.view_model.ViewModel;
+import javafx.beans.binding.Bindings;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.ComboBox;
@@ -12,7 +23,16 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
 
-public class MonthlyCalendarController implements Initializable {
+public class MonthlyCalendarController implements Initializable, ViewModelBindingController {
+
+    private MonthlyCalendarViewModel viewModel;
+
+    @FXML
+    private MonthPage monthPage;
+
+    private final ObservableList<Entry<String>> entryList = FXCollections.observableArrayList();
+
+    private Calendar calendar;
 
     @FXML
     private JFXDrawer collapsedNavPanel;
@@ -33,9 +53,38 @@ public class MonthlyCalendarController implements Initializable {
         calendarType.getItems().addAll("Month", "Week", "Day");
     }
 
+    private void handleEvent(CalendarEvent event) {
+        System.out.println(event.getEntry().getTitle());
+        System.out.println(event.getEventType());
+        System.out.println(this.entryList);
+        System.out.println(this.viewModel.getEntryList());
+    }
+
     @FXML
     void calendarTypeSelected(ActionEvent event) throws IOException {
         String selected = calendarType.getValue();
         NavigationHelper.switchCalendarPageType(event, selected);
+    }
+
+    @Override
+    public void init(ViewModel viewModel) {
+        this.viewModel = (MonthlyCalendarViewModel) viewModel;
+
+        Bindings.bindContentBidirectional(this.entryList, this.viewModel.getEntryList());
+
+        Calendar calendar = new Calendar("all");
+        this.calendar = calendar;
+
+        for (Entry<String> entry : this.entryList) {
+            entry.setCalendar(calendar);
+        }
+
+        EventHandler<CalendarEvent> eventHandler = this::handleEvent;
+        calendar.addEventHandler(eventHandler);
+
+        CalendarSource source = new CalendarSource();
+        source.getCalendars().add(calendar);
+
+        monthPage.getCalendarSources().add(source);
     }
 }

--- a/src/main/java/gui/view/ViewModelBindingController.java
+++ b/src/main/java/gui/view/ViewModelBindingController.java
@@ -1,0 +1,7 @@
+package gui.view;
+
+import gui.view_model.ViewModel;
+
+public interface ViewModelBindingController {
+    void init(ViewModel viewModel);
+}

--- a/src/main/java/gui/view/WeeklyCalendarController.java
+++ b/src/main/java/gui/view/WeeklyCalendarController.java
@@ -2,6 +2,7 @@ package gui.view;
 
 import com.jfoenix.controls.JFXDrawer;
 import gui.utility.NavigationHelper;
+import gui.view_model.ViewModel;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.ComboBox;
@@ -12,7 +13,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
 
-public class WeeklyCalendarController implements Initializable {
+public class WeeklyCalendarController implements Initializable, ViewModelBindingController {
 
     @FXML
     private JFXDrawer collapsedNavPanel;
@@ -37,5 +38,10 @@ public class WeeklyCalendarController implements Initializable {
     void calendarTypeSelected(ActionEvent event) throws IOException {
         String selected = calendarType.getValue();
         NavigationHelper.switchCalendarPageType(event, selected);
+    }
+
+    @Override
+    public void init(ViewModel viewModel) {
+
     }
 }

--- a/src/main/java/gui/view_model/MonthlyCalendarViewModel.java
+++ b/src/main/java/gui/view_model/MonthlyCalendarViewModel.java
@@ -1,0 +1,48 @@
+package gui.view_model;
+
+import com.calendarfx.model.Entry;
+import data_gateway.event.EventReader;
+import gui.model.EventModelManager;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MonthlyCalendarViewModel extends ViewModel {
+
+    private final EventModelManager manager;
+
+    private final ObservableList<Entry<String>> entryList;
+
+    public MonthlyCalendarViewModel(EventModelManager manager) {
+        this.manager = manager;
+
+        List<Entry<String>> newList = new ArrayList<>();
+
+        List<EventReader> eventReaderList = this.manager.getEvents();
+        for (EventReader er : eventReaderList) {
+            newList.add(eventReaderToEntry(er));
+        }
+
+        this.entryList = FXCollections.observableArrayList(newList);
+
+
+    }
+
+    public ObservableList<Entry<String>> getEntryList() {
+        System.out.println(this.entryList);
+        return this.entryList;
+    }
+
+    private Entry<String> eventReaderToEntry(EventReader eventReader) {
+        Entry<String> entry = new Entry<>(eventReader.getName());
+        entry.changeStartTime(eventReader.getStartTime());
+        entry.changeEndTime(eventReader.getEndTime());
+        LocalDate date = LocalDate.of(2021, 12, 8);
+        entry.changeStartDate(date);
+        entry.changeEndDate(date);
+        return entry;
+    }
+}

--- a/src/main/java/gui/view_model/ViewModel.java
+++ b/src/main/java/gui/view_model/ViewModel.java
@@ -1,0 +1,4 @@
+package gui.view_model;
+
+public abstract class ViewModel {
+}

--- a/src/main/java/gui/view_model/ViewModelFactory.java
+++ b/src/main/java/gui/view_model/ViewModelFactory.java
@@ -1,0 +1,24 @@
+package gui.view_model;
+
+
+import gui.model.EventModelManager;
+
+public class ViewModelFactory {
+
+    private final MonthlyCalendarViewModel monthlyCalendarViewModel;
+    private final WeeklyCalendarViewModel weeklyCalendarViewModel;
+
+    public ViewModelFactory(EventModelManager manager) {
+        this.monthlyCalendarViewModel = new MonthlyCalendarViewModel(manager);
+        this.weeklyCalendarViewModel = new WeeklyCalendarViewModel(manager);
+    }
+
+    public MonthlyCalendarViewModel getMonthlyCalendarViewModel() {
+        return monthlyCalendarViewModel;
+    }
+
+    public WeeklyCalendarViewModel getWeeklyCalendarViewModel() {
+        return weeklyCalendarViewModel;
+    }
+
+}

--- a/src/main/java/gui/view_model/WeeklyCalendarViewModel.java
+++ b/src/main/java/gui/view_model/WeeklyCalendarViewModel.java
@@ -1,0 +1,47 @@
+package gui.view_model;
+
+import com.calendarfx.model.Entry;
+import data_gateway.event.EventReader;
+import gui.model.EventModelManager;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WeeklyCalendarViewModel extends ViewModel {
+
+    private final EventModelManager manager;
+
+    private final ObservableList<Entry<String>> entryList;
+
+    public WeeklyCalendarViewModel(EventModelManager manager) {
+        this.manager = manager;
+
+        List<Entry<String>> newList = new ArrayList<>();
+
+        List<EventReader> eventReaderList = this.manager.getEvents();
+        for (EventReader er : eventReaderList) {
+            newList.add(eventReaderToEntry(er));
+        }
+
+        this.entryList = FXCollections.observableArrayList(newList);
+
+
+    }
+
+    public ObservableList<Entry<String>> getEntryList() {
+        return this.entryList;
+    }
+
+    private Entry<String> eventReaderToEntry(EventReader eventReader) {
+        Entry<String> entry = new Entry<>(eventReader.getName());
+        entry.changeStartTime(eventReader.getStartTime());
+        entry.changeEndTime(eventReader.getEndTime());
+        LocalDate date = LocalDate.of(2021, 12, 8);
+        entry.changeStartDate(date);
+        entry.changeEndDate(date);
+        return entry;
+    }
+}

--- a/src/main/resources/monthlyCalendar.fxml
+++ b/src/main/resources/monthlyCalendar.fxml
@@ -9,7 +9,7 @@
    <children>
       <AnchorPane fx:id="mainBackground" layoutX="294.0" prefHeight="800.0" prefWidth="740.0" style="-fx-background-color: #E5E5E5;" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="50.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
          <children>
-            <MonthPage layoutX="22.0" layoutY="90.0" prefHeight="683.0" prefWidth="906.0" AnchorPane.bottomAnchor="40.0" AnchorPane.leftAnchor="45.0" AnchorPane.rightAnchor="45.0" AnchorPane.topAnchor="85.0" />
+            <MonthPage fx:id="monthPage" layoutX="22.0" layoutY="90.0" prefHeight="683.0" prefWidth="906.0" AnchorPane.bottomAnchor="40.0" AnchorPane.leftAnchor="45.0" AnchorPane.rightAnchor="45.0" AnchorPane.topAnchor="85.0" />
             <ComboBox fx:id="calendarType" layoutX="778.0" layoutY="27.0" onAction="#calendarTypeSelected" prefHeight="39.0" prefWidth="150.0" promptText="Month" AnchorPane.bottomAnchor="733.6666666666666" AnchorPane.rightAnchor="22.0" AnchorPane.topAnchor="27.0" />
          </children></AnchorPane>
       <JFXDrawer fx:id="collapsedNavPanel" defaultDrawerSize="50.0" layoutX="-225.0" layoutY="145.0" prefHeight="800.0" prefWidth="50.0" style="-fx-background-color: ffffff;" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="950.0" AnchorPane.topAnchor="0.0" />

--- a/src/main/resources/weeklyCalendar.fxml
+++ b/src/main/resources/weeklyCalendar.fxml
@@ -9,7 +9,7 @@
    <children>
       <AnchorPane fx:id="mainBackground" layoutX="294.0" prefHeight="800.0" prefWidth="740.0" style="-fx-background-color: #E5E5E5;" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="50.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
          <children>
-            <WeekPage layoutX="28.0" layoutY="89.0" prefHeight="676.0" prefWidth="893.0" AnchorPane.bottomAnchor="40.0" AnchorPane.leftAnchor="45.0" AnchorPane.rightAnchor="45.0" AnchorPane.topAnchor="85.0" />
+            <WeekPage fx:id="weekPage" layoutX="28.0" layoutY="89.0" prefHeight="676.0" prefWidth="893.0" AnchorPane.bottomAnchor="40.0" AnchorPane.leftAnchor="45.0" AnchorPane.rightAnchor="45.0" AnchorPane.topAnchor="85.0" />
             <ComboBox fx:id="calendarType" layoutX="778.0" layoutY="27.0" onAction="#calendarTypeSelected" prefHeight="39.0" prefWidth="150.0" promptText="Week" AnchorPane.bottomAnchor="733.6666666666666" AnchorPane.rightAnchor="22.0" AnchorPane.topAnchor="27.0" />
          </children></AnchorPane>
       <JFXDrawer fx:id="collapsedNavPanel" defaultDrawerSize="50.0" layoutX="-225.0" layoutY="145.0" prefHeight="800.0" prefWidth="50.0" style="-fx-background-color: ffffff;" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="950.0" AnchorPane.topAnchor="0.0" />


### PR DESCRIPTION
1. Created view model factory to return view models, to be injected into fx-controllers (the model class that view models depend on are not included, but a sample/ dummy model is included for me to try out/ test)
2. Added a `ViewModelBindingController` interface for all controllers who need a view model to implement (actually only the Navigation controllers do not need implement this)
3. Created `AdaptedFXMLLoader` to not only load the fxml content and instantiate the associated controller, but also **_inject the view model into the controller_** after instantiation (by calling the `init()` method in `ViewModelBindingController` interface. this is also why i created the interface). A problem was that `NavigationHelper` is static, so I couldnt inject the `ViewModelFactory` into it for it to get the various view models to be injected into the fx-controllers. So I let `NavigationHelper` hold an instance of `AdaptedFXMLLoader` and let `AdaptedFXMLLoader` create the `ViewModelFactory` which it uses to inject view models into fx-controllers whenever being called. But I'm not sure if having `ViewModelFactory` being constructed in `AdaptedFXMLLoader` is a good idea (versus instantiating it in `GUIDriver`, for example).