### PR TITLE
Added/ changed methods in request boundaries

### DIFF
--- a/src/main/java/consoleapp/eventadapters/EventController.java
+++ b/src/main/java/consoleapp/eventadapters/EventController.java
@@ -13,6 +13,7 @@ import services.strategybuilding.DatesForm;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -84,6 +85,17 @@ public class EventController {
     }
 
     public List<HashMap<String, String>> getEvents() {
-        return eventGetter.getEvents();
+        List<HashMap<String, String>> hashMapList = new ArrayList<>();
+        List<EventInfo> eventInfos = eventGetter.getEvents();
+        for (EventInfo info : eventInfos) {
+            HashMap<String, String> infoMap = new HashMap<>();
+            infoMap.put("name", info.getName());
+            infoMap.put("start", info.getStartTime().toString());
+            infoMap.put("end", info.getEndTime().toString());
+            infoMap.put("tags", info.getTags().toString());
+            infoMap.put("dates", info.getDates().toString());
+            hashMapList.add(infoMap);
+        }
+        return hashMapList;
     }
 }

--- a/src/main/java/gui/viewmodel/MonthlyCalendarViewModel.java
+++ b/src/main/java/gui/viewmodel/MonthlyCalendarViewModel.java
@@ -1,6 +1,7 @@
 package gui.viewmodel;
 
 import com.calendarfx.model.Entry;
+import datagateway.Observer;
 import datagateway.event.EventReader;
 import datagateway.event.ObservableEventRepository;
 import gui.utility.EventHelper;
@@ -9,7 +10,7 @@ import javafx.collections.ObservableList;
 
 import java.util.List;
 
-public class MonthlyCalendarViewModel extends ViewModel {
+public class MonthlyCalendarViewModel extends ViewModel implements Observer<EventReader> {
 
     private final ObservableEventRepository repository;
 
@@ -33,6 +34,11 @@ public class MonthlyCalendarViewModel extends ViewModel {
     }
 
     public void handleUpdate(EventReader eventReader) {
+
+    }
+
+    @Override
+    public void notifyObserver(EventReader entity) {
 
     }
 }

--- a/src/main/java/gui/viewmodel/TodoListPageViewModel.java
+++ b/src/main/java/gui/viewmodel/TodoListPageViewModel.java
@@ -1,5 +1,6 @@
 package gui.viewmodel;
 
+import datagateway.Observer;
 import datagateway.task.ObservableTaskRepository;
 import datagateway.task.TaskReader;
 import javafx.collections.FXCollections;
@@ -9,7 +10,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.List;
 
-public class TodoListPageViewModel extends ViewModel{
+public class TodoListPageViewModel extends ViewModel implements Observer<TaskReader> {
 
     private final ObservableTaskRepository repository;
 
@@ -54,4 +55,8 @@ public class TodoListPageViewModel extends ViewModel{
 
     }
 
+    @Override
+    public void notifyObserver(TaskReader entity) {
+
+    }
 }

--- a/src/main/java/gui/viewmodel/ViewModelFactory.java
+++ b/src/main/java/gui/viewmodel/ViewModelFactory.java
@@ -10,16 +10,30 @@ public class ViewModelFactory {
     private final MonthlyCalendarViewModel monthlyCalendarViewModel;
     private final WeeklyCalendarViewModel weeklyCalendarViewModel;
     private final TodoListPageViewModel todoListPageViewModel;
+    private final ObservableRepositoryFactory repositoryFactory;
 
-    public ViewModelFactory(ObservableEventRepository eventRepository,
-                            ObservableTaskRepository taskRepository) {
+    public ViewModelFactory(ObservableRepositoryFactory repositoryFactory) {
+        this.repositoryFactory = repositoryFactory;
+        ObservableEventRepository eventRepository = repositoryFactory.makeEventRepository();
+        ObservableTaskRepository taskRepository = repositoryFactory.makeTaskRepository();
+
         this.monthlyCalendarViewModel = new MonthlyCalendarViewModel(eventRepository);
         this.weeklyCalendarViewModel = new WeeklyCalendarViewModel(eventRepository);
         this.todoListPageViewModel = new TodoListPageViewModel(taskRepository);
+        addObserversToRepositories();
     }
 
-    public ViewModelFactory(ObservableRepositoryFactory repositoryFactory) {
-        this(repositoryFactory.makeEventRepository(), repositoryFactory.makeTaskRepository());
+    private void addObserversToRepositories() {
+        ObservableEventRepository eventRepository = repositoryFactory.makeEventRepository();
+        ObservableTaskRepository taskRepository = repositoryFactory.makeTaskRepository();
+
+        eventRepository.addCreationObserver(monthlyCalendarViewModel);
+        eventRepository.addUpdateObserver(monthlyCalendarViewModel);
+        eventRepository.addCreationObserver(weeklyCalendarViewModel);
+        eventRepository.addUpdateObserver(weeklyCalendarViewModel);
+
+        taskRepository.addCreationObserver(todoListPageViewModel);
+        taskRepository.addUpdateObserver(todoListPageViewModel);
     }
 
     public MonthlyCalendarViewModel getMonthlyCalendarViewModel() {

--- a/src/main/java/gui/viewmodel/WeeklyCalendarViewModel.java
+++ b/src/main/java/gui/viewmodel/WeeklyCalendarViewModel.java
@@ -1,6 +1,7 @@
 package gui.viewmodel;
 
 import com.calendarfx.model.Entry;
+import datagateway.Observer;
 import datagateway.event.EventReader;
 import datagateway.event.ObservableEventRepository;
 import gui.utility.EventHelper;
@@ -9,7 +10,7 @@ import javafx.collections.ObservableList;
 
 import java.util.List;
 
-public class WeeklyCalendarViewModel extends ViewModel {
+public class WeeklyCalendarViewModel extends ViewModel implements Observer<EventReader> {
 
     private final ObservableEventRepository repository;
 
@@ -33,6 +34,11 @@ public class WeeklyCalendarViewModel extends ViewModel {
     }
 
     public void handleUpdate(EventReader eventReader) {
+
+    }
+
+    @Override
+    public void notifyObserver(EventReader entity) {
 
     }
 }

--- a/src/main/java/services/eventpresentation/CalendarEventRequestBoundary.java
+++ b/src/main/java/services/eventpresentation/CalendarEventRequestBoundary.java
@@ -4,6 +4,6 @@ import java.util.HashMap;
 import java.util.List;
 
 public interface CalendarEventRequestBoundary {
-    List<HashMap<String, String>> getEvents();
+    List<EventInfo> getEvents();
     EventInfo getEventByName(String name);
 }

--- a/src/main/java/services/eventpresentation/EventGetter.java
+++ b/src/main/java/services/eventpresentation/EventGetter.java
@@ -21,25 +21,13 @@ public class EventGetter implements CalendarEventRequestBoundary {
      * pass the events as DTOs to the presenter to present all events.
      */
     @Override
-    public List<HashMap<String, String>> getEvents() {
-        List<HashMap<String, String>> event_data = new ArrayList<>();
-        for(EventReader event : calendarManager.getAllEvents()) {
-            event_data.add(getEvent(event));
+    public List<EventInfo> getEvents() {
+        List<EventInfo> eventInfos = new ArrayList<>();
+        for(EventReader eventReader : calendarManager.getAllEvents()) {
+            eventInfos.add(new EventInfoFromReader(eventReader));
         }
 
-        return event_data;
-    }
-
-    private HashMap<String, String> getEvent(EventReader event) {
-        HashMap<String, String> event_data = new HashMap<>();
-        event_data.put("name", event.getName());
-        event_data.put("start", event.getStartTime().toString());
-        event_data.put("end", event.getEndTime().toString());
-        event_data.put("tags", event.getTags().toString());
-        event_data.put("dates", event.getDates().toString());
-
-        return event_data;
-
+        return eventInfos;
     }
 
     @Override

--- a/src/main/java/services/taskpresentation/TaskGetter.java
+++ b/src/main/java/services/taskpresentation/TaskGetter.java
@@ -3,6 +3,7 @@ package services.taskpresentation;
 import datagateway.task.TaskReader;
 import datagateway.task.TodoListManager;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -29,6 +30,22 @@ public class TaskGetter implements TodoListRequestBoundary {
                 }
             }
         return null;
+    }
+
+    /**
+     * Get all tasks.
+     * @return a list of TaskInfo
+     */
+    @Override
+    public List<TaskInfo> getTasks() {
+        Map<Long, List<TaskReader>> taskMap = todoListManager.getAllTasks();
+        List<TaskInfo> taskInfos = new ArrayList<>();
+        for (List<TaskReader> todoListTasks : taskMap.values()) {
+            for (TaskReader tr : todoListTasks) {
+                taskInfos.add(new TaskInfoFromTaskReader(tr));
+            }
+        }
+        return taskInfos;
     }
 
 }

--- a/src/main/java/services/taskpresentation/TodoListRequestBoundary.java
+++ b/src/main/java/services/taskpresentation/TodoListRequestBoundary.java
@@ -1,5 +1,8 @@
 package services.taskpresentation;
 
+import java.util.List;
+
 public interface TodoListRequestBoundary {
     TaskInfo getTaskById(Long id);
+    List<TaskInfo> getTasks();
 }

--- a/src/test/java/EventGetterTest.java
+++ b/src/test/java/EventGetterTest.java
@@ -64,28 +64,37 @@ public class EventGetterTest {
     }
 
     @Test
-    void getEvent() {
-        HashMap<String, String> map1 = new HashMap<>();
-        map1.put("name", "mock1");
-        map1.put("start", LocalTime.of(12, 0).toString());
-        map1.put("end", LocalTime.of(14, 0).toString());
-        map1.put("tags", tags1.toString());
-        map1.put("dates", nov25Nov27.toString());
+    void getEvents() {
+        MockEventReader eventReader1 = new MockEventReader(1L, "mock1",
+                LocalTime.of(12, 0), LocalTime.of(14, 0), tags1, nov25Nov27);
+        EventInfo eventInfo1 = new EventInfoFromReader(eventReader1);
+        MockEventReader eventReader2 = new MockEventReader(2L, "mock2",
+                LocalTime.of(14, 0), LocalTime.of(16, 0), tags2, nov25Nov26);
+        EventInfo eventInfo2 = new EventInfoFromReader(eventReader2);
 
-        HashMap<String, String> map2 = new HashMap<>();
-        map2.put("name", "mock2");
-        map2.put("start", LocalTime.of(14, 0).toString());
-        map2.put("end", LocalTime.of(16, 0).toString());
-        map2.put("tags", tags2.toString());
-        map2.put("dates", nov25Nov26.toString());
+        List<EventInfo> expected = new ArrayList<>();
+        expected.add(eventInfo1);
+        expected.add(eventInfo2);
 
-        List<HashMap<String, String>> expected = new ArrayList<>();
-        expected.add(map1);
-        expected.add(map2);
+        List<EventInfo> actual = eventGetter.getEvents();
 
-        List<HashMap<String, String>> actual = eventGetter.getEvents();
+        assertEquals(expected.size(), actual.size());
 
-        assertEquals(expected, actual);
+        assertEquals(eventInfo1.getId(), actual.get(0).getId());
+        assertEquals(eventInfo1.getName(), actual.get(0).getName());
+        assertEquals(eventInfo1.getCompleted(), actual.get(0).getCompleted());
+        assertEquals(eventInfo1.getDates(), actual.get(0).getDates());
+        assertEquals(eventInfo1.getEndTime(), actual.get(0).getEndTime());
+        assertEquals(eventInfo1.getStartTime(), actual.get(0).getStartTime());
+        assertEquals(eventInfo1.getTags(), actual.get(0).getTags());
+
+        assertEquals(eventInfo2.getId(), actual.get(1).getId());
+        assertEquals(eventInfo2.getName(), actual.get(1).getName());
+        assertEquals(eventInfo2.getCompleted(), actual.get(1).getCompleted());
+        assertEquals(eventInfo2.getDates(), actual.get(1).getDates());
+        assertEquals(eventInfo2.getEndTime(), actual.get(1).getEndTime());
+        assertEquals(eventInfo2.getStartTime(), actual.get(1).getStartTime());
+        assertEquals(eventInfo2.getTags(), actual.get(1).getTags());
     }
 
     @Test


### PR DESCRIPTION
Previously, the request boundaries for event getting and task getting was not standardized e.g. in event getter, we are getting `List<HashMap>` instead of `List<EventInfo>` when getting all events, and in task getter, we didnt have the method to get all tasks.