### PR TITLE
updating optional parsing method to actually work

### DIFF
--- a/src/main/java/consoleapp/ApplicationDriver.java
+++ b/src/main/java/consoleapp/ApplicationDriver.java
@@ -324,7 +324,7 @@ public class ApplicationDriver {
             DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(dateTimeFormat);
             return LocalDateTime.parse(timeString, dateTimeFormatter);
         } catch (DateTimeParseException e) {
-            DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(dateTimeFormat);
+            DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(dateFormat);
             return LocalDate.parse(timeString, dateFormatter).atTime(defaultTime);
         }
     }


### PR DESCRIPTION
previously was attempting to reparse with the primary pattern. Input of the alternate pattern would always return null (as if nothing was input)